### PR TITLE
Remove tests on push

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Test package
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build-ubuntu-latest:


### PR DESCRIPTION
If you contribute only via PRs, this is redundant, and would save some time. Closes #9 