### PR TITLE
Fix publication on pypi for 2FA

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -19,7 +19,7 @@ jobs:
         pip install setuptools wheel twine
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ SETUP = Setup(
     name="hipe4ml_converter",
 
     # LAST-TAG is a placeholder. Automatically replaced at deploy time with the right tag
-    version="0.0.5",
+    version="0.0.6",
     description="Minimal heavy ion physics environment for Machine Learning",
     url="https://github.com/hipe4ml/hipe4ml_converter",
     author="hipe4ml-developers",


### PR DESCRIPTION
Publication of the package on `pypi` fails with the following error:
```
ERROR    HTTPError: 401 Unauthorized from https://upload.pypi.org/legacy/       
         User *** has two factor auth enabled, an API Token or Trusted      
         Publisher must be used to upload in place of password.                 
```
Likely because of 2FA (see e.g. [link](https://stackoverflow.com/questions/72010704/twine-upload-credentials-not-update-httperror-401-unauthorized))